### PR TITLE
Use builtin Net::HTTP debug output for more detailed network debugging.

### DIFF
--- a/lib/jets/api/core.rb
+++ b/lib/jets/api/core.rb
@@ -52,16 +52,10 @@ module Jets::Api
 
     def load_json(url, res)
       uri = URI(url)
-      if ENV['JETS_API_DEBUG']
-        puts "res.code #{res.code}"
-        puts "res.body #{res.body}"
-      end
       if processable?(res.code)
         JSON.load(res.body)
       else
         puts "Error: Non-successful http response status code: #{res.code}"
-        puts "headers: #{res.each_header.to_h.inspect}"
-        puts "Jets API #{url}" if ENV['JETS_API_DEBUG']
         raise "Jets API called failed: #{uri.host}"
       end
     end
@@ -78,6 +72,7 @@ module Jets::Api
       http = Net::HTTP.new(uri.host, uri.port)
       http.open_timeout = http.read_timeout = 30
       http.use_ssl = true if uri.scheme == 'https'
+      http.set_debug_output($stdout) if ENV['JETS_API_DEBUG']
       http
     end
     memoize :http


### PR DESCRIPTION
This adds verbose builtin Net::HTTP debug output to network requests. I've included an example of a single request below. I understand this is very verbose so it may be a matter of preference. One way to make this easy to toggle on/off would be to use a different environment variable for this `JETS_API_DEBUG_VERBSE`. 

The output for every HTTP request looks like this (<- is a request header and -> is a response header)
```
opening connection to api.rubyonjets.com:443...
opened
starting SSL for api.rubyonjets.com:443...
SSL established, protocol: TLSv1.3, cipher: TLS_AES_128_GCM_SHA256
<- "POST https://api.rubyonjets.com/v1/gems/registered HTTP/1.1\r\nAccept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3\r\nAccept: */*\r\nUser-Agent: Ruby\r\nAuthorization:REDACTED\r\nContent-Type: application/vnd.api+json\r\nContent-Length: 211\r\nConnection: close\r\nHost: api.rubyonjets.com\r\n\r\n"
<- "{\"jets_env\":\"development\",\"name\":\"techbot-dev\",\"region\":\"us-east-2\",\"account\":\"REDACTED\",\"project_id\":\"techbot\",\"jets_api_version\":\"0.2.0\",\"jets_version\":\"5.0.9\",\"ruby_version\":\"3.2.2\",\"ruby_folder\":\"3.2.0\"}"
-> "HTTP/1.1 200 OK\r\n"
-> "Content-Type: application/json\r\n"
-> "Content-Length: 36\r\n"
-> "Connection: close\r\n"
-> "Date: Wed, 31 Jan 2024 15:02:32 GMT\r\n"
-> "x-amzn-RequestId: cd6f8745-25fc-4ffd-8738-adb3a5ce03c8\r\n"
-> "X-Runtime: 0.170432\r\n"
-> "x-jets-prewarm-count: 0\r\n"
-> "X-Request-Id: c57c2998-e8bb-4aa3-9202-f9fdac6efa00\r\n"
-> "x-amz-apigw-id: SaQYsH78vHcEGPA=\r\n"
-> "vary: Origin\r\n"
-> "Cache-Control: max-age=0, private, must-revalidate\r\n"
-> "ETag: W/\"f9a528075561f25637bb9ec21a643861\"\r\n"
-> "X-Amzn-Trace-Id: Root=1-65ba6104-047d88cb5da0c04b2697494e;Sampled=0;lineage=668ef8b2:0\r\n"
-> "x-jets-call-count: 1\r\n"
-> "X-Cache: Miss from cloudfront\r\n"
-> "Via: 1.1 cfdcdd1b2ce759e37ac4aa58359c9c64.cloudfront.net (CloudFront)\r\n"
-> "X-Amz-Cf-Pop: DFW56-P3\r\n"
-> "X-Amz-Cf-Id: 9dVySCdDTlOAl9_TuSTdHV5TJeR-rOnlpxcPh4306grUmgjMf8_JKw==\r\n"
-> "\r\n"
reading 36 bytes...
-> "{\"gems\":[\"ethon\",\"typhoeus\",\"ynab\"]}"
read 36 bytes
Conn close
```
