### PR TITLE
 skip `weird_gem?` check 

### DIFF
--- a/lib/jets/api/gems/check.rb
+++ b/lib/jets/api/gems/check.rb
@@ -212,7 +212,7 @@ class Jets::Api::Gems
     #   https://stackoverflow.com/questions/5165950/how-do-i-get-a-list-of-gems-that-are-installed-that-have-native-extensions
     def gemspec_compiled_gems
       specs = Gem::Specification.each.select { |spec| spec.extensions.any? }
-      specs.reject! { |spec| weird_gem?(spec.name) }
+      # specs.reject! { |spec| weird_gem?(spec.name) }
       specs.map(&:full_name)
     end
 


### PR DESCRIPTION
So, something changed with bundler and this line now chokes on the `json` gem.
`bundle show json` now prints this to stdout in my app:
```
1 : jsonapi-renderer
2 : json-jwt
3 : json
0 : - exit -
```
...then waits for input. This causes the `weird_gem?('json')` method to hang indefinitely.

I'm not sure what the right fix is here or what even `weird_gem?` was trying to solve. Commenting out this check lets me move forward.